### PR TITLE
Update to Version 7.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,29 @@
+
+name: CI
+# This workflow is triggered on pushes to the repository.
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '*/1440 * * * *'
+
+jobs:
+  test:
+    # Job name is Test
+    name: Test
+    # This job runs on macOS
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Dependencies
+        run: |
+          sudo gem install cocoapods
+          pod repo update
+      - name: Build
+        run: pod lib lint --use-libraries --allow-warnings || pod lib lint --allow-warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-osx_image: xcode10
-language: objective-c
-script:
-- sudo gem install cocoapods -v 1.5.3
-- travis_retry pod repo update > /dev/null
-- pod lib lint --use-libraries --allow-warnings || pod lib lint --allow-warnings
-- xcodebuild -project mParticle-Google-Analytics-Firebase.xcodeproj -scheme mParticle-Google-Analytics-FirebaseTests -destination 'platform=iOS Simulator,OS=12.0,name=iPhone XS' test

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 6.10'
+    s.ios.dependency 'Firebase/Core', '~> 7.1'
     s.ios.pod_target_xcconfig = {
         'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
     }

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -20,5 +20,11 @@ Pod::Spec.new do |s|
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
     s.ios.dependency 'Firebase/Core', '~> 6.10'
+    s.ios.pod_target_xcconfig = {
+        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+    }
+    s.ios.user_target_xcconfig = {
+        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+    }
 
 end

--- a/mParticle-Google-Analytics-Firebase.xcodeproj/project.pbxproj
+++ b/mParticle-Google-Analytics-Firebase.xcodeproj/project.pbxproj
@@ -3,17 +3,17 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		268B5E47BD6C2240E09AFDA1 /* libPods-mParticle-Google-Analytics-Firebase.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A44652B3A475234FD1288C8A /* libPods-mParticle-Google-Analytics-Firebase.a */; };
-		2783403B1F8BA83C386FD58D /* libPods-mParticle-Google-Analytics-FirebaseTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C951B3FCEF97BECF5993FB75 /* libPods-mParticle-Google-Analytics-FirebaseTests.a */; };
+		9E07647ED59A184D760532D5 /* Pods_mParticle_Google_Analytics_FirebaseTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 832A4675698B38F3468A6AED /* Pods_mParticle_Google_Analytics_FirebaseTests.framework */; };
 		D316BD43217F670600688E56 /* mParticle-Firebase-Analytics.h in Headers */ = {isa = PBXBuildFile; fileRef = D316BD35217F670500688E56 /* mParticle-Firebase-Analytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D316BD4E217F67BC00688E56 /* MPKitFirebaseAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = D316BD4C217F67BC00688E56 /* MPKitFirebaseAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D316BD4F217F67BC00688E56 /* MPKitFirebaseAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = D316BD4D217F67BC00688E56 /* MPKitFirebaseAnalytics.m */; };
 		D3C7855521FF6CEC00FE47D2 /* mParticle_Firebase_AnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C7855421FF6CEC00FE47D2 /* mParticle_Firebase_AnalyticsTests.m */; };
 		D3C7855721FF6CEC00FE47D2 /* mParticle_Google_Analytics_Firebase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D316BD32217F670500688E56 /* mParticle_Google_Analytics_Firebase.framework */; };
+		FE916649F0D7F3FD56E4F254 /* Pods_mParticle_Google_Analytics_Firebase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08ECAEF5C250588122DB4CAD /* Pods_mParticle_Google_Analytics_Firebase.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,15 +27,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		08ECAEF5C250588122DB4CAD /* Pods_mParticle_Google_Analytics_Firebase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mParticle_Google_Analytics_Firebase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		226C2DCC9EB073556AADF7CC /* Pods-mParticle-Google-Analytics-Firebase.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Google-Analytics-Firebase.release.xcconfig"; path = "Target Support Files/Pods-mParticle-Google-Analytics-Firebase/Pods-mParticle-Google-Analytics-Firebase.release.xcconfig"; sourceTree = "<group>"; };
 		342132EB30BC43AB21903604 /* Pods-mParticle-Google-Analytics-FirebaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Google-Analytics-FirebaseTests.debug.xcconfig"; path = "Target Support Files/Pods-mParticle-Google-Analytics-FirebaseTests/Pods-mParticle-Google-Analytics-FirebaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 		619F501A03C247A2E37DEE7F /* Pods-mParticle-Firebase-AnalyticsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Firebase-AnalyticsTests.debug.xcconfig"; path = "Target Support Files/Pods-mParticle-Firebase-AnalyticsTests/Pods-mParticle-Firebase-AnalyticsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		68CC4538AEE8899C249C5CC2 /* Pods-mParticle-Google-Analytics-Firebase.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Google-Analytics-Firebase.debug.xcconfig"; path = "Target Support Files/Pods-mParticle-Google-Analytics-Firebase/Pods-mParticle-Google-Analytics-Firebase.debug.xcconfig"; sourceTree = "<group>"; };
+		832A4675698B38F3468A6AED /* Pods_mParticle_Google_Analytics_FirebaseTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_mParticle_Google_Analytics_FirebaseTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B4577DFDEF24FE84AAC1F94 /* Pods-mParticle-Firebase-Analytics.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Firebase-Analytics.debug.xcconfig"; path = "Target Support Files/Pods-mParticle-Firebase-Analytics/Pods-mParticle-Firebase-Analytics.debug.xcconfig"; sourceTree = "<group>"; };
-		A44652B3A475234FD1288C8A /* libPods-mParticle-Google-Analytics-Firebase.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-mParticle-Google-Analytics-Firebase.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C36975864B0BB8F3A6A952E3 /* Pods-mParticle-Firebase-AnalyticsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Firebase-AnalyticsTests.release.xcconfig"; path = "Target Support Files/Pods-mParticle-Firebase-AnalyticsTests/Pods-mParticle-Firebase-AnalyticsTests.release.xcconfig"; sourceTree = "<group>"; };
 		C7B8FAD18792236712DCE464 /* Pods-mParticle-Firebase-Analytics.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-mParticle-Firebase-Analytics.release.xcconfig"; path = "Target Support Files/Pods-mParticle-Firebase-Analytics/Pods-mParticle-Firebase-Analytics.release.xcconfig"; sourceTree = "<group>"; };
-		C951B3FCEF97BECF5993FB75 /* libPods-mParticle-Google-Analytics-FirebaseTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-mParticle-Google-Analytics-FirebaseTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3085197219B605900D1C15A /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
 		D316BD32217F670500688E56 /* mParticle_Google_Analytics_Firebase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Google_Analytics_Firebase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D316BD35217F670500688E56 /* mParticle-Firebase-Analytics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "mParticle-Firebase-Analytics.h"; sourceTree = "<group>"; };
@@ -61,7 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				268B5E47BD6C2240E09AFDA1 /* libPods-mParticle-Google-Analytics-Firebase.a in Frameworks */,
+				FE916649F0D7F3FD56E4F254 /* Pods_mParticle_Google_Analytics_Firebase.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,7 +70,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3C7855721FF6CEC00FE47D2 /* mParticle_Google_Analytics_Firebase.framework in Frameworks */,
-				2783403B1F8BA83C386FD58D /* libPods-mParticle-Google-Analytics-FirebaseTests.a in Frameworks */,
+				9E07647ED59A184D760532D5 /* Pods_mParticle_Google_Analytics_FirebaseTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -135,8 +135,8 @@
 				D316BD53217F6D8B00688E56 /* OptimizelySDKiOS.framework */,
 				D316BD54217F6D8B00688E56 /* OptimizelySDKShared.framework */,
 				D316BD55217F6D8B00688E56 /* OptimizelySDKUserProfileService.framework */,
-				A44652B3A475234FD1288C8A /* libPods-mParticle-Google-Analytics-Firebase.a */,
-				C951B3FCEF97BECF5993FB75 /* libPods-mParticle-Google-Analytics-FirebaseTests.a */,
+				08ECAEF5C250588122DB4CAD /* Pods_mParticle_Google_Analytics_Firebase.framework */,
+				832A4675698B38F3468A6AED /* Pods_mParticle_Google_Analytics_FirebaseTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -192,6 +192,7 @@
 				D3C7854E21FF6CEB00FE47D2 /* Sources */,
 				D3C7854F21FF6CEB00FE47D2 /* Frameworks */,
 				D3C7855021FF6CEB00FE47D2 /* Resources */,
+				EDCC24752867DC8890A43B4A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -298,6 +299,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EDCC24752867DC8890A43B4A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-mParticle-Google-Analytics-FirebaseTests/Pods-mParticle-Google-Analytics-FirebaseTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-mParticle-Google-Analytics-FirebaseTests/Pods-mParticle-Google-Analytics-FirebaseTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-mParticle-Google-Analytics-FirebaseTests/Pods-mParticle-Google-Analytics-FirebaseTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.h
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.h
@@ -16,4 +16,6 @@
 
 static NSString * _Nonnull const kMPFIRGoogleAppIDKey = @"firebaseAppId";
 static NSString * _Nonnull const kMPFIRSenderIDKey = @"googleProjectNumber";
+static NSString * _Nonnull const kMPFIRAPIKey = @"firebaseAPIKey";
+static NSString * _Nonnull const kMPFIRProjectIDKey = @"firebaseProjectId";
 static NSString * _Nonnull const kMPFIRUserIdFieldKey = @"userIdField";

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -52,9 +52,17 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
         dispatch_once(&FirebasePredicate, ^{
             NSString *googleAppId = configuration[kMPFIRGoogleAppIDKey];
             NSString *gcmSenderId = configuration[kMPFIRSenderIDKey];
+            NSString *firAPIKey = configuration[kMPFIRAPIKey];
+            NSString *firProjectId = configuration[kMPFIRProjectIDKey];
             
             if (googleAppId && ![googleAppId isEqualToString:@""] && gcmSenderId && ![gcmSenderId isEqualToString:@""]) {
                 FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:googleAppId GCMSenderID:gcmSenderId];
+                if (firAPIKey) {
+                    options.APIKey = firAPIKey;
+                }
+                if (firProjectId) {
+                    options.projectID = firProjectId;
+                }
                 
                 self.firebaseOptions = options;
                 [FIRApp configureWithOptions:options];
@@ -219,7 +227,7 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     }
 
     event.name = [self standardizeNameOrKey:event.name forEvent:YES];
-    [FIRAnalytics setScreenName:event.name screenClass:nil];
+    [FIRAnalytics logEventWithName:kFIREventScreenView parameters:@{kFIRParameterScreenName: event.name}];
     
     return [self execStatus:MPKitReturnCodeSuccess];
 }

--- a/mParticle-Google-Analytics-FirebaseTests/mParticle_Firebase_AnalyticsTests.m
+++ b/mParticle-Google-Analytics-FirebaseTests/mParticle_Firebase_AnalyticsTests.m
@@ -43,7 +43,7 @@
 
 - (void)testStarted {
     MPKitFirebaseAnalytics *exampleKit = [[MPKitFirebaseAnalytics alloc] init];
-    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096"}];
+    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096", kMPFIRAPIKey: @"AIzaSyDVH6Lxu4QvIWheB14FChPIdI6FiCi8PXY", kMPFIRProjectIDKey: @"mparticle-integration-test"}];
     XCTAssertTrue(exampleKit.started);
 }
 
@@ -61,7 +61,7 @@
 
 - (void)testLogCommerceEvent {
     MPKitFirebaseAnalytics *exampleKit = [[MPKitFirebaseAnalytics alloc] init];
-    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096"}];
+    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096", kMPFIRAPIKey: @"AIzaSyDVH6Lxu4QvIWheB14FChPIdI6FiCi8PXY", kMPFIRProjectIDKey: @"mparticle-integration-test"}];
     
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithAction:MPCommerceEventActionCheckoutOptions];
     
@@ -73,7 +73,7 @@
 
 - (void)testLogCommerceEventPurchase {
     MPKitFirebaseAnalytics *exampleKit = [[MPKitFirebaseAnalytics alloc] init];
-    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096"}];
+    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096", kMPFIRAPIKey: @"AIzaSyDVH6Lxu4QvIWheB14FChPIdI6FiCi8PXY", kMPFIRProjectIDKey: @"mparticle-integration-test"}];
     
     MPProduct *product = [[MPProduct alloc] initWithName:@"Tardis" sku:@"9who" quantity:@1 price:@42.0];
     
@@ -86,7 +86,7 @@
 
 - (void)testLogEvent {
     MPKitFirebaseAnalytics *exampleKit = [[MPKitFirebaseAnalytics alloc] init];
-    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096"}];
+    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096", kMPFIRAPIKey: @"AIzaSyDVH6Lxu4QvIWheB14FChPIdI6FiCi8PXY", kMPFIRProjectIDKey: @"mparticle-integration-test"}];
     
     MPEvent *event = [[MPEvent alloc] initWithName:@"example" type:MPEventTypeOther];
     
@@ -97,7 +97,7 @@
 
 - (void)testLogEventWithNilEvent {
     MPKitFirebaseAnalytics *exampleKit = [[MPKitFirebaseAnalytics alloc] init];
-    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096"}];
+    [exampleKit didFinishLaunchingWithConfiguration:@{kMPFIRGoogleAppIDKey:@"1:338209672096:ios:57235e7ff821ba85", kMPFIRSenderIDKey:@"338209672096", kMPFIRAPIKey: @"AIzaSyDVH6Lxu4QvIWheB14FChPIdI6FiCi8PXY", kMPFIRProjectIDKey: @"mparticle-integration-test"}];
     
     MPEvent *event;
     


### PR DESCRIPTION
Updating to Firebase Version 7.1
* setScreenName: was deprecated
* Unit tests no longer worked with just App ID and Sender ID so added API Key and Project ID in a way that won't affect normal use of GooogleService-Info.plist. We may wish to add those keys to the UI so that clients can use Firebase without GooogleService-Info.plist but that may have unforeseen issues.