### PR TITLE
Update Deprecated Commerce Constants

### DIFF
--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -384,11 +384,15 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     if (product.sku) {
         [parameters setObject:product.sku forKey:kFIRParameterItemID];
     }
-    if (product.name && product.category) {
-        NSArray *itemsArray = @[
-            @{kFIRParameterItemName : product.name, kFIRParameterItemCategory : product.category},
-        ];
-        [parameters setObject:itemsArray forKey:kFIRParameterItems];
+    NSMutableDictionary *itemDict = [[NSMutableDictionary alloc] init];
+    if (product.name) {
+        itemDict[kFIRParameterItemName] = product.name;
+    }
+    if (product.category) {
+        itemDict[kFIRParameterItemCategory] = product.category;
+    }
+    if (itemDict.count > 0) {
+        [parameters setObject:@[itemDict] forKey:kFIRParameterItems];
     }
     if (product.price) {
         [parameters setObject:@(product.price.doubleValue * product.quantity.doubleValue) forKey:kFIRParameterValue];

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -196,7 +196,7 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
             
             parameters = [self getParameterForCommerceEvent:commerceEvent andProduct:nil withValue:value];
             
-            [FIRAnalytics logEventWithName:kFIREventEcommercePurchase
+            [FIRAnalytics logEventWithName:kFIREventPurchase
                                 parameters:parameters];
         }
             break;
@@ -204,7 +204,7 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
         case MPCommerceEventActionRefund: {
             NSNumber *value = commerceEvent.transactionAttributes.revenue;
             
-            [FIRAnalytics logEventWithName:kFIREventPurchaseRefund
+            [FIRAnalytics logEventWithName:kFIREventRefund
                                 parameters:@{
                                              kFIRParameterCurrency: commerceEvent.currency,
                                              kFIRParameterValue: value,
@@ -384,11 +384,11 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     if (product.sku) {
         [parameters setObject:product.sku forKey:kFIRParameterItemID];
     }
-    if (product.name) {
-        [parameters setObject:product.name forKey:kFIRParameterItemName];
-    }
-    if (product.category) {
-        [parameters setObject:product.category forKey:kFIRParameterItemCategory];
+    if (product.name && product.category) {
+        NSArray *itemsArray = @[
+            @{kFIRParameterItemName : product.name, kFIRParameterItemCategory : product.category},
+        ];
+        [parameters setObject:itemsArray forKey:kFIRParameterItems];
     }
     if (product.price) {
         [parameters setObject:@(product.price.doubleValue * product.quantity.doubleValue) forKey:kFIRParameterValue];


### PR DESCRIPTION
Some constants were deprecated by Google's documentation but not deprecated as to provide a warning in the code. This change updates the keys and structure of optional information being sent to Firebase, mostly around commerce events.