### PR TITLE
Format event name joining multiple whitespaces into one

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,8 +6,8 @@ target 'mParticle-Google-Analytics-Firebase' do
   use_frameworks!
 
   # Pods for mParticle-Google-Analytics-Firebase
-pod 'Firebase/Core'
-pod 'mParticle-Apple-SDK/mParticle'
+  pod 'Firebase/Core'
+  pod 'mParticle-Apple-SDK/mParticle'
 
 end
 
@@ -16,8 +16,8 @@ target 'mParticle-Google-Analytics-FirebaseTests' do
   use_frameworks!
 
   # Pods for mParticle-Google-Analytics-FirebaseTests
-pod 'Firebase/Core'
-pod 'mParticle-Apple-SDK/mParticle'
-pod 'OCMock'
+  pod 'Firebase/Core'
+  pod 'mParticle-Apple-SDK/mParticle'
+  pod 'OCMock'
 
 end

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -18,7 +18,7 @@ static NSString *const kMPFIRUserIdValueDeviceStamp = @"deviceApplicationStamp";
 static NSString *const reservedPrefixOne = @"firebase_";
 static NSString *const reservedPrefixTwo = @"google_";
 static NSString *const reservedPrefixThree = @"ga_";
-static NSString *const firebaseAllowedCharacters = @"_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+static NSString *const firebaseAllowedCharacters = @" _abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 static NSString *const aToZCharacters = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 const NSInteger FIR_MAX_CHARACTERS_EVENT_NAME_INDEX = 39;
@@ -246,9 +246,9 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
 }
 
 - (NSString *)standardizeNameOrKey:(NSString *)nameOrKey forEvent:(BOOL)forEvent {
-    NSString *standardizedString =  [nameOrKey stringByReplacingOccurrencesOfString:@"  " withString:@"_"];
     NSCharacterSet *notAllowedChars = [[NSCharacterSet characterSetWithCharactersInString:firebaseAllowedCharacters] invertedSet];
-    standardizedString = [[standardizedString componentsSeparatedByCharactersInSet:notAllowedChars] componentsJoinedByString:@""];
+    NSString* allowedNameOrKey = [[nameOrKey componentsSeparatedByCharactersInSet:notAllowedChars] componentsJoinedByString:@""];
+    NSString *standardizedString = [allowedNameOrKey stringByReplacingOccurrencesOfString:@" " withString:@"_"];
     if (standardizedString.length > reservedPrefixOne.length && [standardizedString hasPrefix:reservedPrefixOne]) {
         standardizedString = [standardizedString substringFromIndex:reservedPrefixOne.length];
     } else if (standardizedString.length > reservedPrefixTwo.length && [standardizedString hasPrefix:reservedPrefixTwo]) {

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -1,6 +1,5 @@
 #import "MPKitFirebaseAnalytics.h"
 #import "Firebase.h"
-#import "MPEnums.h"
 
 @interface MPKitFirebaseAnalytics()
 

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -17,7 +17,7 @@ static NSString *const kMPFIRUserIdValueDeviceStamp = @"deviceApplicationStamp";
 static NSString *const reservedPrefixOne = @"firebase_";
 static NSString *const reservedPrefixTwo = @"google_";
 static NSString *const reservedPrefixThree = @"ga_";
-static NSString *const firebaseAllowedCharacters = @" _abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+static NSString *const firebaseAllowedCharacters = @"_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 static NSString *const aToZCharacters = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 const NSInteger FIR_MAX_CHARACTERS_EVENT_NAME_INDEX = 39;
@@ -245,9 +245,16 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
 }
 
 - (NSString *)standardizeNameOrKey:(NSString *)nameOrKey forEvent:(BOOL)forEvent {
-    NSCharacterSet *notAllowedChars = [[NSCharacterSet characterSetWithCharactersInString:firebaseAllowedCharacters] invertedSet];
+    NSCharacterSet *whitespacesSet = [NSCharacterSet whitespaceCharacterSet];
+    NSMutableCharacterSet *firebaseAllowedCharacterSet = [NSMutableCharacterSet characterSetWithCharactersInString:firebaseAllowedCharacters];
+    [firebaseAllowedCharacterSet formUnionWithCharacterSet:whitespacesSet];
+    NSCharacterSet *notAllowedChars = [firebaseAllowedCharacterSet invertedSet];
     NSString* allowedNameOrKey = [[nameOrKey componentsSeparatedByCharactersInSet:notAllowedChars] componentsJoinedByString:@""];
-    NSString *standardizedString = [allowedNameOrKey stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"  +" options:NSRegularExpressionCaseInsensitive error:nil];
+    NSString *trimmedString = [regex stringByReplacingMatchesInString:allowedNameOrKey options:0 range:NSMakeRange(0, [allowedNameOrKey length]) withTemplate:@" "];
+
+    NSString *standardizedString = [trimmedString stringByReplacingOccurrencesOfString:@" " withString:@"_"];
     if (standardizedString.length > reservedPrefixOne.length && [standardizedString hasPrefix:reservedPrefixOne]) {
         standardizedString = [standardizedString substringFromIndex:reservedPrefixOne.length];
     } else if (standardizedString.length > reservedPrefixTwo.length && [standardizedString hasPrefix:reservedPrefixTwo]) {


### PR DESCRIPTION
From a given event name: `Checkout - Placer Order`
Return this event name as: `Checkout_Placer_Order` instead of `Checkout__Place_Order`