### PR TITLE
Update Analytics Parameters

### DIFF
--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -390,15 +390,16 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     if (product.sku) {
         [parameters setObject:product.sku forKey:kFIRParameterItemID];
     }
-    NSMutableDictionary *itemDict = [[NSMutableDictionary alloc] init];
+    NSMutableArray *itemArray = [[NSMutableArray alloc] init];
     if (product.name) {
-        itemDict[kFIRParameterItemName] = product.name;
+        [itemArray addObject:product.name];
+        [parameters setObject:product.name forKey:kFIRParameterItemName];
+    }
+    if (itemArray.count > 0) {
+        [parameters setObject:itemArray forKey:kFIRParameterItems];
     }
     if (product.category) {
-        itemDict[kFIRParameterItemCategory] = product.category;
-    }
-    if (itemDict.count > 0) {
-        [parameters setObject:@[itemDict] forKey:kFIRParameterItems];
+        [parameters setObject:product.category forKey:kFIRParameterItemCategory];
     }
     if (product.price) {
         [parameters setObject:@(product.price.doubleValue * product.quantity.doubleValue) forKey:kFIRParameterValue];


### PR DESCRIPTION
The "items" parameter should contain an array of names while name and category should be included in the standard dicitonary of parameters. https://github.com/tinode/ios/blob/076b77cbf7cae270f07879141fa437f0354400d6/Pods/FirebaseAnalytics/Frameworks/FirebaseAnalytics.framework/Headers/FIRParameterNames.h#L679

TP Issue #65000