### PR TITLE
Fix Checkout Step 0

### DIFF
--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -411,7 +411,7 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     if (value) {
         [parameters setObject:value forKey:kFIRParameterValue];
     }
-    if (commerceEvent.checkoutStep) {
+    if (commerceEvent.checkoutStep != NSNotFound) {
         [parameters setObject:@(commerceEvent.checkoutStep) forKey:kFIRParameterCheckoutStep];
     }
     if (commerceEvent.checkoutOptions) {


### PR DESCRIPTION
Unlike the other parameter values, the checkout step is an integer rather than an object pointer. This ensures that step '0' will be sent.