### PR TITLE
Fix Event Forwarded names for Accurate Reporting in UI

### DIFF
--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -182,8 +182,8 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
         return [self execStatus:MPKitReturnCodeFail];
     }
 
-    event.name = [self standardizeNameOrKey:event.name forEvent:YES];
-    [FIRAnalytics logEventWithName:kFIREventScreenView parameters:@{kFIRParameterScreenName: event.name}];
+    NSString *standardizedFirebaseEventName = [self standardizeNameOrKey:event.name forEvent:YES];
+    [FIRAnalytics logEventWithName:kFIREventScreenView parameters:@{kFIRParameterScreenName: standardizedFirebaseEventName}];
     
     return [self execStatus:MPKitReturnCodeSuccess];
 }
@@ -193,9 +193,9 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
         return [self execStatus:MPKitReturnCodeFail];
     }
     
-    event.name = [self standardizeNameOrKey:event.name forEvent:YES];
+    NSString *standardizedFirebaseEventName = [self standardizeNameOrKey:event.name forEvent:YES];
     event.customAttributes = [self standardizeValues:event.customAttributes forEvent:YES];
-    [FIRAnalytics logEventWithName:event.name
+    [FIRAnalytics logEventWithName:standardizedFirebaseEventName
                         parameters:event.customAttributes];
     
     return [self execStatus:MPKitReturnCodeSuccess];


### PR DESCRIPTION
The GA firebase kit appear to be mutating the event name(https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase/blob/eb35fa6f3d7fa477aa6033890e5a4e7d6235199b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m#L196) which is causing the standardized event names to appear in the event forwarder tab in the mParticle UI. 

This fix addresses that. 