### PR TITLE
Update mParticle-Google-Analytics-Firebase.podspec

### DIFF
--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -20,11 +20,5 @@ Pod::Spec.new do |s|
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
     s.ios.dependency 'Firebase/Core', '~> 7.1'
-    s.ios.pod_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
-    s.ios.user_target_xcconfig = {
-        'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
-    }
 
 end


### PR DESCRIPTION
# Summary

Remove arm64 from the exclude architectures for simulator so that developers in our team can run the app in the simulator when working with M1 macs.

I also created a support request for this matter:
https://support.mparticle.com/hc/en-us/requests/7000