### PR TITLE
feat: Split CheckoutOption to shipping and payments

### DIFF
--- a/mParticle-Google-Analytics-Firebase.xcodeproj/xcshareddata/xcschemes/mParticle-Google-Analytics-Firebase.xcscheme
+++ b/mParticle-Google-Analytics-Firebase.xcodeproj/xcshareddata/xcschemes/mParticle-Google-Analytics-Firebase.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D316BD31217F670500688E56"
+            BuildableName = "mParticle_Google_Analytics_Firebase.framework"
+            BlueprintName = "mParticle-Google-Analytics-Firebase"
+            ReferencedContainer = "container:mParticle-Google-Analytics-Firebase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D316BD31217F670500688E56"
-            BuildableName = "mParticle_Google_Analytics_Firebase.framework"
-            BlueprintName = "mParticle-Google-Analytics-Firebase"
-            ReferencedContainer = "container:mParticle-Google-Analytics-Firebase.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:mParticle-Google-Analytics-Firebase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.h
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.h
@@ -19,3 +19,7 @@ static NSString * _Nonnull const kMPFIRSenderIDKey = @"googleProjectNumber";
 static NSString * _Nonnull const kMPFIRAPIKey = @"firebaseAPIKey";
 static NSString * _Nonnull const kMPFIRProjectIDKey = @"firebaseProjectId";
 static NSString * _Nonnull const kMPFIRUserIdFieldKey = @"userIdField";
+
+static NSString * _Nonnull const kMPFIRGA4CommerceEventType = @"GA4.CommerceEventType";
+static NSString * _Nonnull const kMPFIRGA4PaymentType = @"GA4.PaymentType";
+static NSString * _Nonnull const kMPFIRGA4ShippingTier = @"GA4.ShippingTier";

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -1,4 +1,3 @@
-//#import "MPKitFirebaseAnalytics.h"
 #import "MPKitFirebaseAnalytics.h"
 #import "Firebase.h"
 

--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -1,3 +1,4 @@
+//#import "MPKitFirebaseAnalytics.h"
 #import "MPKitFirebaseAnalytics.h"
 #import "Firebase.h"
 
@@ -110,69 +111,12 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
 
 - (MPKitExecStatus *)routeCommerceEvent:(MPCommerceEvent *)commerceEvent {
     NSDictionary<NSString *, id> *parameters = [self getParameterForCommerceEvent:commerceEvent];
-    
-    switch (commerceEvent.action) {
-        case MPCommerceEventActionAddToCart: {
-            [FIRAnalytics logEventWithName:kFIREventAddToCart
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionRemoveFromCart: {
-            [FIRAnalytics logEventWithName:kFIREventRemoveFromCart
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionAddToWishList: {
-            [FIRAnalytics logEventWithName:kFIREventAddToWishlist
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionCheckout: {
-            [FIRAnalytics logEventWithName:kFIREventBeginCheckout
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionCheckoutOptions: {
-            [FIRAnalytics logEventWithName:kFIREventSetCheckoutOption
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionClick: {
-            NSMutableDictionary<NSString *, id> *mutableParameters = [parameters mutableCopy];
-            mutableParameters[kFIRParameterContentType] = @"product";
-            
-            [FIRAnalytics logEventWithName:kFIREventSelectContent
-                                parameters:mutableParameters];
-        }
-            break;
-            
-        case MPCommerceEventActionViewDetail: {
-            [FIRAnalytics logEventWithName:kFIREventViewItem
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionPurchase: {
-            [FIRAnalytics logEventWithName:kFIREventPurchase
-                                parameters:parameters];
-        }
-            break;
-            
-        case MPCommerceEventActionRefund: {
-            [FIRAnalytics logEventWithName:kFIREventRefund
-                                parameters:parameters];
-        }
-            break;
-            
-        default:
-            return [self execStatus:MPKitReturnCodeFail];
-            break;
+    NSString *eventName = [self getEventNameForCommerceEvent:commerceEvent parameters:parameters];
+    if (!eventName) {
+        return [self execStatus:MPKitReturnCodeFail];
     }
+    
+    [FIRAnalytics logEventWithName:eventName parameters:parameters];
     
     return [self execStatus:MPKitReturnCodeSuccess];
 }
@@ -195,8 +139,7 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     
     NSString *standardizedFirebaseEventName = [self standardizeNameOrKey:event.name forEvent:YES];
     event.customAttributes = [self standardizeValues:event.customAttributes forEvent:YES];
-    [FIRAnalytics logEventWithName:standardizedFirebaseEventName
-                        parameters:event.customAttributes];
+    [FIRAnalytics logEventWithName:standardizedFirebaseEventName parameters:event.customAttributes];
     
     return [self execStatus:MPKitReturnCodeSuccess];
 }
@@ -338,7 +281,46 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     }
 }
 
--(NSDictionary<NSString *, id> *)getParameterForCommerceEvent:(MPCommerceEvent *)commerceEvent {
+- (NSString *)getEventNameForCommerceEvent:(MPCommerceEvent *)commerceEvent parameters:(NSDictionary<NSString *, id> *)parameters {
+    switch (commerceEvent.action) {
+        case MPCommerceEventActionAddToCart:
+            return kFIREventAddToCart;
+        case MPCommerceEventActionRemoveFromCart:
+            return kFIREventRemoveFromCart;
+        case MPCommerceEventActionAddToWishList:
+            return kFIREventAddToWishlist;
+        case MPCommerceEventActionCheckout:
+            return kFIREventBeginCheckout;
+        case MPCommerceEventActionCheckoutOptions: {
+            NSArray *ga4CommerceEventType = commerceEvent.customFlags[kMPFIRGA4CommerceEventType];
+            if (ga4CommerceEventType) {
+                if ([ga4CommerceEventType containsObject:kFIREventAddShippingInfo]) {
+                    return kFIREventAddShippingInfo;
+                } else if ([ga4CommerceEventType containsObject:kFIREventAddPaymentInfo]) {
+                    return kFIREventAddPaymentInfo;
+                } else {
+                    NSLog(@"Warning: Firebase has deprecated CheckoutOption in favor of 'add_shipping_info' and 'add_payment_info'. Review mParticle docs for Firebase for the custom flags to add.");
+                    return kFIREventSetCheckoutOption;
+                }
+            } else {
+                NSLog(@"Warning: Firebase has deprecated CheckoutOption in favor of 'add_shipping_info' and 'add_payment_info'. Review mParticle docs for Firebase for the custom flags to add.");
+                return kFIREventSetCheckoutOption;
+            }
+        }
+        case MPCommerceEventActionClick:
+            return kFIREventSelectContent;
+        case MPCommerceEventActionViewDetail:
+            return kFIREventViewItem;
+        case MPCommerceEventActionPurchase:
+            return kFIREventPurchase;
+        case MPCommerceEventActionRefund:
+            return kFIREventRefund;
+        default:
+            return nil;
+    }
+}
+
+- (NSDictionary<NSString *, id> *)getParameterForCommerceEvent:(MPCommerceEvent *)commerceEvent {
     NSMutableDictionary<NSString *, id> *parameters = [[NSMutableDictionary alloc] init];
     
     NSMutableArray *itemArray = [[NSMutableArray alloc] init];
@@ -395,6 +377,26 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     }
     if (commerceEvent.transactionAttributes.couponCode) {
         [parameters setObject:commerceEvent.transactionAttributes.couponCode forKey:kFIRParameterCoupon];
+    }
+    
+    if (commerceEvent.action == MPCommerceEventActionClick) {
+        [parameters setObject:@"product" forKey:kFIRParameterContentType];
+    }
+    
+    NSArray *ga4CommerceEventType = commerceEvent.customFlags[kMPFIRGA4CommerceEventType];
+    if (ga4CommerceEventType) {
+        if ([ga4CommerceEventType containsObject:kFIREventAddShippingInfo]) {
+            NSArray *shippingTier = commerceEvent.customFlags[kMPFIRGA4ShippingTier];
+            if (shippingTier.count > 0) {
+                [parameters setObject:shippingTier[0] forKey:kFIRParameterShippingTier];
+            }
+        }
+        if ([ga4CommerceEventType containsObject:kFIREventAddPaymentInfo]) {
+            NSArray *paymentInfo = commerceEvent.customFlags[kMPFIRGA4PaymentType];
+            if (paymentInfo.count > 0) {
+                [parameters setObject:paymentInfo[0] forKey:kFIRParameterPaymentType];
+            }
+        }
     }
     
     return parameters;


### PR DESCRIPTION
# Summary

A new codepath is required because our API does not support `add_shipping_info`, nor `add_payment_info`, which GA4 now supports.

Firebase (and consequently, Google Analytics 4, which uses Firebases data model and is what prompted this PR), deprecated `set_checkout_option` in favor of `add_shipping_info` and `add_payment_info`.  These will be passed via a custom flag of `GA.CommerceEventType` on a `Checkout_Option` ProductActionType.

If the value of `GA.CommerceEventType` is `add_shipping_info`, a user can optionally add a `shipping_tier` custom flag.  If `add_payment_info` is chosen, a user can optionally add `payment_type` custom flag.

Also did some minor refactoring both for clarity as well as to enable unit testing without mocking Firebase.
