### PR TITLE
Update Firebase import in MPKitFirebaseAnalytics.m

### DIFF
--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -1,5 +1,5 @@
 #import "MPKitFirebaseAnalytics.h"
-#import "Firebase.h"
+#import <Firebase/Firebase.h>
 
 @interface MPKitFirebaseAnalytics()
 


### PR DESCRIPTION
## Summary
In our project we are adding a new parameter to the Cocoapods installation that changes how the Pods project is generated.
`:generate_multiple_pod_projects => true`

Instead of having one single project file for all Pods, we have one project file for each Pod. After adding this change, the import updated in this PR fails with "'Firebase.h' file not found". By introducing this change it can successfully import Firebase from the separate module.

## Testing Plan
We built the project with both generate_multiple_pod_projects on and off, and it builds successfully.

## Reference Issue
https://support.mparticle.com/hc/en-us/requests/8756
