### PR TITLE
feat: Add Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Firebase",
                url: "https://github.com/firebase/firebase-ios-sdk.git",
-               .upToNextMajor(from: "9.0.0")),
+               .upToNextMajor(from: "10.6.0")),
     ],
     targets: [
         .target(
@@ -27,7 +27,7 @@ let package = Package(
               .product(name: "FirebaseAnalytics", package: "Firebase"),
             ],
             path: "mParticle-Google-Analytics-Firebase",
-            exclude: ["Info.plist"],
+            exclude: ["Info.plist", "dummy.swift"],
             publicHeadersPath: "."),
     ]
 )

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 9.0'
+    s.ios.dependency 'Firebase/Core', '~> 10.23'
 
 end

--- a/mParticle-Google-Analytics-Firebase.xcodeproj/project.pbxproj
+++ b/mParticle-Google-Analytics-Firebase.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		2780D0912792152200942CC7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2780D0902792152200942CC7 /* GoogleService-Info.plist */; };
+		53D881FD2BBD9CC40066BB30 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 53D881FC2BBD9CC40066BB30 /* PrivacyInfo.xcprivacy */; };
 		D316BD4E217F67BC00688E56 /* MPKitFirebaseAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = D316BD4C217F67BC00688E56 /* MPKitFirebaseAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D316BD4F217F67BC00688E56 /* MPKitFirebaseAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = D316BD4D217F67BC00688E56 /* MPKitFirebaseAnalytics.m */; };
 		D39C3DE528C78D5B00432A0C /* dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39C3DE428C78D5B00432A0C /* dummy.swift */; };
@@ -79,6 +80,7 @@
 
 /* Begin PBXFileReference section */
 		2780D0902792152200942CC7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		53D881FC2BBD9CC40066BB30 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D3085197219B605900D1C15A /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Carthage/Build/iOS/OCMock.framework; sourceTree = "<group>"; };
 		D316BD32217F670500688E56 /* mParticle_Google_Analytics_Firebase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Google_Analytics_Firebase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D316BD36217F670600688E56 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 				D316BD36217F670600688E56 /* Info.plist */,
 				D316BD4C217F67BC00688E56 /* MPKitFirebaseAnalytics.h */,
 				D316BD4D217F67BC00688E56 /* MPKitFirebaseAnalytics.m */,
+				53D881FC2BBD9CC40066BB30 /* PrivacyInfo.xcprivacy */,
 				D39C3DE428C78D5B00432A0C /* dummy.swift */,
 			);
 			path = "mParticle-Google-Analytics-Firebase";
@@ -292,6 +295,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53D881FD2BBD9CC40066BB30 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mParticle-Google-Analytics-Firebase/PrivacyInfo.xcprivacy
+++ b/mParticle-Google-Analytics-Firebase/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict/>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict/>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
 ## Summary
 - Add privacy manifest
 - Update Firebase to 10.23.0 which includes their privacy manifest

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Already confirmed in the GA4 repo that no code changes are required to move from v9 to v10 of firebase, so I just confirmed the project built and could be added to both a Cocoapods and SPM test project and confirmed the privacy manifest was added.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6309
