### PR TITLE
feat: Add Consent Support

### DIFF
--- a/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
+++ b/mParticle-Google-Analytics-Firebase/MPKitFirebaseAnalytics.m
@@ -5,9 +5,11 @@
     #if __has_include(<FirebaseCore/FirebaseCore.h>)
         #import <FirebaseCore/FirebaseCore.h>
         #import <FirebaseAnalytics/FIRAnalytics.h>
+        #import <FirebaseAnalytics/FIRAnalytics+Consent.h>
     #else
         #import "FirebaseCore/FirebaseCore.h"
         #import "FirebaseAnalytics/FIRAnalytics.h"
+        #import "FirebaseAnalytics/FIRAnalytics+Consent.h"
     #endif
 #endif
 
@@ -39,6 +41,15 @@ static NSString *const reservedPrefixThree = @"ga_";
 static NSString *const firebaseAllowedCharacters = @"_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 static NSString *const aToZCharacters = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 static NSString *const instanceIdIntegrationKey = @"app_instance_id";
+
+static NSString *const kMPFIRGA4AdStorageKey = @"ad_storage";
+static NSString *const kMPFIRGA4AdUserDataKey = @"ad_user_data";
+static NSString *const kMPFIRGA4AdPersonalizationKey = @"ad_personalization";
+static NSString *const kMPFIRGA4AnalyticsStorageKey = @"analytics_storage";
+static NSString *const kMPFIRGA4DefaultAdStorageKey = @"defaultAdStorageConsentSDK";
+static NSString *const kMPFIRGA4DefaultAdUserDataKey = @"defaultAdUserDataConsentSDK";
+static NSString *const kMPFIRGA4DefaultAdPersonalizationKey = @"defaultAdPersonalizationConsentSDK";
+static NSString *const kMPFIRGA4DefaultAnalyticsStorageKey = @"defaultAnalyticsStorageConsentSDK";
 
 const NSInteger FIR_MAX_CHARACTERS_EVENT_NAME_INDEX = 39;
 const NSInteger FIR_MAX_CHARACTERS_IDENTITY_NAME_INDEX = 23;
@@ -73,6 +84,8 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
             forwardRequestsServerSide = true;
             [self updateInstanceIDIntegration];
         }
+        
+        [self updateConsent];
         
         _started = YES;
         
@@ -330,6 +343,88 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     for (NSString *attributeKey in userAttributesKeys) {
         [FIRAnalytics setUserPropertyString:standardizedUserAttributes[attributeKey] forName:attributeKey];
     }
+}
+
+- (MPKitExecStatus *)setConsentState:(nullable MPConsentState *)state {
+    [self updateConsent];
+
+    return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+- (void)updateConsent {
+    FIRConsentStatus adStorageStatus;
+    FIRConsentStatus adUserDataStatus;
+    FIRConsentStatus analyticsStorageStatus;
+    FIRConsentStatus adPersonalizationStatus;
+
+    // Default Consent States
+    if (self.configuration[kMPFIRGA4DefaultAdStorageKey]) {
+        if ([self.configuration[kMPFIRGA4DefaultAdStorageKey] isEqual: @"Granted"]) {
+            adStorageStatus = FIRConsentStatusGranted;
+        } else if ([self.configuration[kMPFIRGA4DefaultAdStorageKey] isEqual: @"Denied"]) {
+            adStorageStatus = FIRConsentStatusDenied;
+        }
+    }
+    if (self.configuration[kMPFIRGA4DefaultAdUserDataKey]) {
+        if ([self.configuration[kMPFIRGA4DefaultAdUserDataKey] isEqual: @"Granted"]) {
+            adUserDataStatus = FIRConsentStatusGranted;
+        } else if ([self.configuration[kMPFIRGA4DefaultAdUserDataKey] isEqual: @"Denied"]) {
+            adUserDataStatus = FIRConsentStatusDenied;
+        }
+    }
+    if (self.configuration[kMPFIRGA4DefaultAnalyticsStorageKey]) {
+        if ([self.configuration[kMPFIRGA4DefaultAnalyticsStorageKey] isEqual: @"Granted"]) {
+            analyticsStorageStatus = FIRConsentStatusGranted;
+        } else if ([self.configuration[kMPFIRGA4DefaultAnalyticsStorageKey] isEqual: @"Denied"]) {
+            analyticsStorageStatus = FIRConsentStatusDenied;
+        }
+    }
+    if (self.configuration[kMPFIRGA4DefaultAdPersonalizationKey]) {
+        if ([self.configuration[kMPFIRGA4DefaultAdPersonalizationKey] isEqual: @"Granted"]) {
+            adPersonalizationStatus = FIRConsentStatusGranted;
+        } else if ([self.configuration[kMPFIRGA4DefaultAdPersonalizationKey] isEqual: @"Denied"]) {
+            adPersonalizationStatus = FIRConsentStatusDenied;
+        }
+    }
+
+    MParticleUser *currentUser = [[[MParticle sharedInstance] identity] currentUser];
+    NSDictionary<NSString *, MPGDPRConsent *> *userConsentMap = currentUser.consentState.gdprConsentState;
+
+    // Update from mParticle consent
+    if (self.configuration[kMPFIRGA4AdStorageKey] && userConsentMap[self.configuration[kMPFIRGA4AdStorageKey]]) {
+        MPGDPRConsent *consent = userConsentMap[self.configuration[kMPFIRGA4AdStorageKey]];
+        adStorageStatus = consent.consented ? FIRConsentStatusGranted : FIRConsentStatusDenied;
+    }
+    if (self.configuration[kMPFIRGA4AdUserDataKey] && userConsentMap[self.configuration[kMPFIRGA4AdUserDataKey]]) {
+        MPGDPRConsent *consent = userConsentMap[self.configuration[kMPFIRGA4AdUserDataKey]];
+        adUserDataStatus = consent.consented ? FIRConsentStatusGranted : FIRConsentStatusDenied;
+    }
+    if (self.configuration[kMPFIRGA4AnalyticsStorageKey] && userConsentMap[self.configuration[kMPFIRGA4AnalyticsStorageKey]]) {
+        MPGDPRConsent *consent = userConsentMap[self.configuration[kMPFIRGA4AnalyticsStorageKey]];
+        analyticsStorageStatus = consent.consented ? FIRConsentStatusGranted : FIRConsentStatusDenied;
+    }
+    if (self.configuration[kMPFIRGA4AdPersonalizationKey] && userConsentMap[self.configuration[kMPFIRGA4AdPersonalizationKey]]) {
+        MPGDPRConsent *consent = userConsentMap[self.configuration[kMPFIRGA4AdPersonalizationKey]];
+        adPersonalizationStatus = consent.consented ? FIRConsentStatusGranted : FIRConsentStatusDenied;
+    }
+
+    // Construct a dictionary of consents
+    NSMutableDictionary *uploadDict = [[NSMutableDictionary alloc] init];
+    if (adStorageStatus) {
+        uploadDict[FIRConsentTypeAdStorage] = adStorageStatus;
+    }
+    if (adUserDataStatus) {
+        uploadDict[FIRConsentTypeAdUserData] = adUserDataStatus;
+    }
+    if (analyticsStorageStatus) {
+        uploadDict[FIRConsentTypeAnalyticsStorage] = analyticsStorageStatus;
+    }
+    if (adPersonalizationStatus) {
+        uploadDict[FIRConsentTypeAdPersonalization] = adPersonalizationStatus;
+    }
+
+    // Update consent state with FIRAnalytics
+    [FIRAnalytics setConsent:uploadDict];
 }
 
 - (NSString *)getEventNameForCommerceEvent:(MPCommerceEvent *)commerceEvent parameters:(NSDictionary<NSString *, id> *)parameters {


### PR DESCRIPTION
## Summary
 - Bring Google consent code to FIrebase.  This wil be a copy and paste of the code from GA4 firebase - [feat: Support Google Consent (#26) · mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4@78d898b](https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/commit/78d898bcd8bde8ac814903f875ba8f8feb5e152e).

 ## Testing Plan
 - Tested in sample app using cocoapods.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6176
