### PR TITLE
Feat: update FirebaseCore to v11

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 10.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 11.8
 binary "https://raw.githubusercontent.com/mParticle/mparticle-apple-sdk/main/mParticle_Apple_SDK.json" ~> 8.19

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-Google-Analytics-Firebase",
-    platforms: [ .iOS(.v11) ],
+    platforms: [ .iOS(.v13) ],
     products: [
         .library(
             name: "mParticle-Google-Analytics-Firebase",
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.22.0")),
       .package(name: "Firebase",
                url: "https://github.com/firebase/firebase-ios-sdk.git",
-               .upToNextMajor(from: "10.23.0")),
+               .upToNextMajor(from: "11.8.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -14,12 +14,12 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/mparticle"
     s.static_framework = true
 
-    s.ios.deployment_target = "11.0"
+    s.ios.deployment_target = "13.0"
     s.ios.source_files      = 'mParticle-Google-Analytics-Firebase/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Google-Analytics-Firebase-Privacy' => ['mParticle-Google-Analytics-Firebase/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 10.23'
+    s.ios.dependency 'Firebase/Core', '~> 11.8'
 
 end


### PR DESCRIPTION
 ## Summary
 - We are currently on Firebase v10 and Google released Firebase v11 as mentioned [here](https://firebase.google.com/support/release-notes/ios#version_1100_-_july_30_2024), this PR is to update the Firebase version to v11

 ## Testing Plan
 - [N] Was this tested locally? If not, explain why.
 - Same as this [PR](https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/pull/31)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6955
