### PR TITLE
feat: iOS Kit Google Analytics Update to 12.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 11.8
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 12.0
 binary "https://raw.githubusercontent.com/mParticle/mparticle-apple-sdk/main/mParticle_Apple_SDK.json" ~> 8.19

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "mParticle-Google-Analytics-Firebase",
-    platforms: [ .iOS(.v13) ],
+    platforms: [ .iOS(.v15) ],
     products: [
         .library(
             name: "mParticle-Google-Analytics-Firebase",
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.22.0")),
       .package(name: "Firebase",
                url: "https://github.com/firebase/firebase-ios-sdk.git",
-               .upToNextMajor(from: "11.8.0")),
+               .upToNextMajor(from: "12.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -14,12 +14,12 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/mparticle"
     s.static_framework = true
 
-    s.ios.deployment_target = "13.0"
+    s.ios.deployment_target = "15.0"
     s.ios.source_files      = 'mParticle-Google-Analytics-Firebase/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Google-Analytics-Firebase-Privacy' => ['mParticle-Google-Analytics-Firebase/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 11.8'
+    s.ios.dependency 'Firebase/Core', '~> 12.0'
 
 end


### PR DESCRIPTION
 ## Summary
 - This PR is to update the Firebase version to [v12](https://firebase.google.com/support/release-notes/ios#version_1200_-_july_15_2025).

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - Same as this [PR](https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/pull/34)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7505
