### PR TITLE
chore: Update to Version 9.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
       .package(url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.22.0")),
+               .upToNextMajor(from: "9.0.0")),
       .package(url: "https://github.com/firebase/firebase-ios-sdk.git",
                .upToNextMajor(from: "12.0.0")),
     ],

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Google-Analytics-Firebase"
-    s.version          = "8.6.1"
+    s.version          = "9.0.0"
     s.summary          = "Google Analytics for Firebase integration for mParticle"
 
     s.description      = <<-DESC
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "15.0"
     s.ios.source_files      = 'mParticle-Google-Analytics-Firebase/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Google-Analytics-Firebase-Privacy' => ['mParticle-Google-Analytics-Firebase/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 9.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.ios.dependency 'Firebase/Core', '~> 12.0'
     


### PR DESCRIPTION
## Summary
 - Bumps the integration version from 8.11.1 to 9.0.0
 - Updates the mParticle-Apple-SDK dependency to ~> 9.0 for both iOS and tvOS platforms in the podspec
 - Updates the Swift Package Manager dependency to .upToNextMajor(from: "9.0.0") in Package.swift

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-773